### PR TITLE
Added support for multiple translation file formats and implemented p…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,78 @@
 # laravel-excel-translations
+
+Laravel Excel Translations Package
+This package allows you to load and use translation strings from Excel and CSV files in your Laravel application. It supports .csv, .xls and .xlsx file formats.
+
+## Installation
+
+1. **Install with Composer:**
+```bash
+composer require muyki/laravel-excel-translations
+```
+
+2. **Save Service Provider:**
+
+It is automatically discovered for Laravel 5.5 and above. For older versions, add the following line to your config/app.php file:
+
+```
+'providers' => [
+    // ...
+    Muyki\LaravelExcelTranslations\LaravelExcelTranslationServiceProvider::class,
+],
+```
+
+3. **Publish:**
+
+You can publish the configuration file if you wish:
+
+```bash
+php artisan vendor:publish --provider="Muyki\LaravelExcelTranslations\LaravelExcelTranslationServiceProvider" --tag="config"
+```
+
+## Usage
+
+1. **Prepare Language Files**:
+
+   Place your translation files in the lang directory. Supported file formats:
+    - .csv
+    - .xls
+    - .xlsx
+    
+    ### **File Structure Example**:
+
+    | Key     | en      | tr           |
+    |:--------|:-------:|-------------:|
+    | welcome | Welcome | Hoş geldiniz |
+    | goodbye | Goodbye | Güle güle    |
+
+## Using Translations:
+
+Use helper functions to get translations:
+
+```
+echo __e('file_name.key'); // Translation in default language
+echo __e('file_name.key', [], 'tr'); // Translation in the specified language
+```
+
+Example:
+
+```
+echo __e('messages.welcome'); // 'Welcome'
+echo __e('messages.welcome', [], 'tr'); // 'Hoş geldiniz'
+```
+
+## Customization
+
+Caching Settings:
+
+You can configure caching from the **config/excel_translations.php** file.
+
+```
+return [
+    'cache' => [
+    'expiration_time' => \DateInterval::createFromDateString('24 hours'),
+    'key' => 'muyki.excel_translations.cache',
+    'store' => 'default',
+    ],
+];
+```

--- a/src/Exceptions/FileNotFoundException.php
+++ b/src/Exceptions/FileNotFoundException.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Muyki\LaravelExcelTranslations\Exceptions;
+
+use Exception;
+use Throwable;
+class FileNotFoundException extends \Exception
+{
+    public function __construct(string $filePath, $message = null, $code = 404, Throwable $previous = null)
+    {
+        $this->filePath = $filePath;
+        $message = $message ?? "File Not Found : '$filePath' ";
+        parent::__construct($message, $code, $previous);
+    }
+
+    public function getFilePath(): string
+    {
+        return $this->filePath;
+    }
+
+    public function report()
+    {
+        \Log::error("File Not Found: " . $this->filePath);
+    }
+
+    public function render($request)
+    {
+        return response()->json([
+            'error' => 'File Not Found',
+            'file' => $this->filePath
+        ], 404);
+    }
+}

--- a/src/Exceptions/LocaleNotFoundException.php
+++ b/src/Exceptions/LocaleNotFoundException.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Muyki\LaravelExcelTranslations\Exceptions;
+
+use Exception;
+use Throwable;
+class LocaleNotFoundException extends \Exception
+{
+
+    protected string $locale;
+
+    public function __construct(string $locale,string $message = null, int $code = 404, Throwable $previous = null)
+    {
+        $this->locale = $locale;
+        $message = $message ?? "Language '$locale' not found.";
+        parent::__construct($message, $code, $previous);
+    }
+
+    public function getLocale(): string
+    {
+        return $this->locale;
+    }
+
+    public function report()
+    {
+        \Log::error("Language Not Found: " . $this->locale);
+    }
+
+    public function render($request)
+    {
+        return response()->json([
+            'error' => 'Language Not Found',
+            'locale' => $this->locale,
+            'available_locales' => config('app.locales', ['en', 'tr'])
+        ], 404);
+    }
+
+}

--- a/src/Exceptions/TranslationKeyNotFoundException.php
+++ b/src/Exceptions/TranslationKeyNotFoundException.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Muyki\LaravelExcelTranslations\Exceptions;
+
+use Exception;
+use Throwable;
+class TranslationKeyNotFoundException extends \Exception
+{
+    protected string $translationKey;
+
+    public function __construct(string $translationKey, $message = null, $code = 404, Throwable $previous = null)
+    {
+        $this->translationKey = $translationKey;
+        $message = $message ?? "Translation key '$translationKey' not found.";
+        parent::__construct($message, $code, $previous);
+    }
+
+    public function getTranslationKey(): string
+    {
+        return $this->translationKey;
+    }
+
+    public function report()
+    {
+        \Log::error("Translation key not found : " . $this->translationKey);
+    }
+
+    public function render($request)
+    {
+        return response()->json([
+            'error' => 'Translation key not found ',
+            'key' => $this->translationKey,
+        ], 404);
+    }
+
+
+
+}

--- a/src/Exceptions/UnsupportedFileFormatException.php
+++ b/src/Exceptions/UnsupportedFileFormatException.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Muyki\LaravelExcelTranslations\Exceptions;
+
+use Exception;
+use Throwable;
+class UnsupportedFileFormatException extends \Exception
+{
+    protected string $fileFormat;
+
+    public function __construct(string $fileFormat, $message = null, $code = 400, Throwable $previous = null)
+    {
+        $this->fileFormat = $fileFormat;
+        $message = $message ?? "File format '$fileFormat' is not supported.";
+        parent::__construct($message, $code, $previous);
+    }
+
+    public function getFileFormat(): string
+    {
+        return $this->fileFormat;
+    }
+
+    public function report()
+    {
+        \Log::error("Unsupported file format: " . $this->fileFormat);
+    }
+
+    public function render($request)
+    {
+        return response()->json([
+            'error' => 'Unsupported file format',
+            'file_format' => $this->fileFormat
+        ], 400);
+    }
+}

--- a/src/LaravelExcelTranslationRegistrar.php
+++ b/src/LaravelExcelTranslationRegistrar.php
@@ -5,6 +5,10 @@ namespace Muyki\LaravelExcelTranslations;
 use Illuminate\Cache\CacheManager;
 use Illuminate\Support\Str;
 use Illuminate\Contracts\Cache\Repository;
+use Muyki\LaravelExcelTranslations\Exceptions\FileNotFoundException;
+use Muyki\LaravelExcelTranslations\Exceptions\LocaleNotFoundException;
+use Muyki\LaravelExcelTranslations\Exceptions\TranslationKeyNotFoundException;
+use Muyki\LaravelExcelTranslations\Exceptions\UnsupportedFileFormatException;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use Illuminate\Support\Facades\File;
 use PhpOffice\PhpSpreadsheet\Reader\Csv;
@@ -66,13 +70,14 @@ class LaravelExcelTranslationRegistrar
     public function parseFile ($file) {
 
         $filePath = base_path('lang/' . $file);
+
         $extension = pathinfo($filePath, PATHINFO_EXTENSION);
 
         $reader = match ($extension) {
             'csv' => new Csv(),   
             'xls' => new Xls(),
             'xlsx' => new Xlsx(),
-            default => throw new \Exception('Unsupported file format'),
+            default => throw new UnsupportedFileFormatException($extension),
         };
 
         $spreadsheet =  $reader->load($filePath); 
@@ -114,17 +119,18 @@ class LaravelExcelTranslationRegistrar
         [$file, $key] = explode(".", $key, 2);
 
         if (!isset($this->data[$file])) {
-            throw new \Exception("File \"$file\" not found!");
+            throw new FileNotFoundException($file);
         }
 
         if (!isset($this->data[$file][$locale])) {
-            throw new \Exception("Locale \"$locale\" not found!");
+            throw new LocaleNotFoundException($locale);
         }
 
         if (!isset($this->data[$file][$locale][$key])) {
-            throw new \Exception("Translation key \"$key\" not found!");
+            throw new TranslationKeyNotFoundException($key);
         }
 
         return $this->data[$file][$locale][$key];
     }
+
 }

--- a/src/LaravelExcelTranslationServiceProvider.php
+++ b/src/LaravelExcelTranslationServiceProvider.php
@@ -11,6 +11,10 @@ class LaravelExcelTranslationServiceProvider extends ServiceProvider
         $this->app->singleton(LaravelExcelTranslationRegistrar::class, function ($app) use ($laravelExcelTranslationsRegistrar) {
             return $laravelExcelTranslationsRegistrar;
         });
+
+        $this->publishes([
+            __DIR__.'/../config/excel_translations.php' => config_path('excel_translations.php'),
+        ], 'config');
     }
 
     public function register()


### PR DESCRIPTION
…ublishable configuration.

- Updated `parseFiles()` method to support multiple file formats (`.csv`, `.xls`, `.xlsx`) by modifying the file collection logic.
- - Implemented publishing the configuration file using `$this->publishes()` in `LaravelExcelTranslationServiceProvider`, allowing users to run `php artisan vendor:publish` to publish the configuration.